### PR TITLE
fix linux64 hash

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,7 +42,7 @@ vagrant_checksums:
   # https://releases.hashicorp.com/vagrant/2.2.3/vagrant_2.2.3_SHA256SUMS
   '2.2.3':
     x86_64:
-      deb: sha256:c53c30178a863d0d0fc505393e680cd9866e1aca590cedddb9b9adc5a1fab919
+      deb: sha256:2b8392dfc02d161f674dde7ad08297e2831b233b14b6db6bb12ac12ae9d90f7f
       dmg: sha256:d6f68ed8d69d6465e13ab668542bacc9a1752cf60f47464fa46604c147c81be4
       rpm: sha256:3bda785e80ddf184b7698f1593d4b95acda2830395a1b4ab2b08cd636c334fdd
 


### PR DESCRIPTION
Hey Andrew noticed you also have an incorrect hash here. I'm guessing HashiCorp must have changed the binary without updating the version at some point.