### PR TITLE
Add support for downloading package to a non tmp location

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,3 +53,19 @@ vagrant_checksums:
       rpm: sha256:660dfd87b2cd893f2ce73748fdb19c6792d6c4232ca242d416370644ce233442
 
 vagrant_mirror: https://releases.hashicorp.com/vagrant
+
+# The following variables can be changed to alter where the vagrant
+# package is downloaded to before being installed.
+# By default the package is downloaded to /tmp
+# If you want to avoid spurious reporting of changes you'll want to adjust
+# this so that the role does not report a change just because the download
+# was deleted from the tmp directory.
+vagrant_pkg_download_dir: /tmp
+
+# Whether to create the download directory, if created it will be owned
+# by the ansible_user rather than root to allow for non-escalated download
+vagrant_create_pkg_download_dir: False
+
+# Whether or not to escalate when downloading, This can only be false if
+# vagrant_pkg_download_dir is writable by the ansible_user.
+vagrant_pkg_download_escalate: "{{ not vagrant_create_pkg_download_dir }}"

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -3,5 +3,5 @@
   become: yes
   become_user: root
   apt:
-    deb: /tmp/{{ vagrant_pkg }}
+    deb: '{{ vagrant_pkg_download_dir }}/{{ vagrant_pkg }}'
     state: present

--- a/tasks/dmg.yml
+++ b/tasks/dmg.yml
@@ -2,7 +2,7 @@
 - name: attach
   become: yes
   become_user: root
-  command: hdiutil attach /tmp/{{ vagrant_pkg }}
+  command: hdiutil attach {{ vagrant_pkg_download_dir }}/{{ vagrant_pkg }}
   args:
     creates: '{{ vagrant_dmg_volume }}'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,12 +18,21 @@
     name: '{{ item }}'
     state: present
 
+- name: create package download dir
+  file:
+    path: '{{ vagrant_pkg_download_dir }}'
+    state: directory
+    owner: '{{ ansible_user }}'
+    mode: "0755"
+  become: True
+  when: vagrant_create_pkg_download_dir
+
 - name: download pkg
-  become: yes
+  become: '{{ vagrant_pkg_download_escalate }}'
   become_user: root
   get_url:
     url: '{{ vagrant_pkg_url }}'
-    dest: /tmp/{{ vagrant_pkg }}
+    dest: '{{ vagrant_pkg_download_dir }}/{{ vagrant_pkg }}'
     checksum: '{{ vagrant_checksum }}'
     mode: 0644
 

--- a/tasks/pkg.yml
+++ b/tasks/pkg.yml
@@ -3,5 +3,5 @@
   become: yes
   become_user: root
   package:
-    name: /tmp/{{ vagrant_pkg }}
+    name: '{{ vagrant_pkg_download_dir }}/{{ vagrant_pkg }}'
     state: present


### PR DESCRIPTION
Currently this role always downloads the vagrant package to /tmp and always escalates to root when downloading the package.

If the /tmp directory is cleaned up, the package will be re-downloaded by a subsequent ansible run which will report changes even though the installed vagrant hasn't been changed at all.

These changes allow the download location to be overriden so that the package can be downloaded to /usr/local/src or similar so it won't be randomly cleaned up.

This also supports creating the download directory owned by a non-root user, this allows the actual download to be run not as root. In general I prefer to run the least ammount of stuff as root.